### PR TITLE
feat: custom scroll-bar colors support for firefox based browsers

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -11,6 +11,15 @@
   background: #000;
 }
 
+@media all and (min--moz-device-pixel-ratio:0) and (min-resolution: 3e1dpcm) {
+  :root {
+    scrollbar-color: #1BFFFF #000000;
+	scrollbar-base-color: #000000;
+  }
+  scrollbar {
+		width: 14px;
+  }
+}
 
 /* Dark Violet */
 .dark-violet {


### PR DESCRIPTION
Para melhorar o PR #39, adicionei suporte de cores pra barras de scroll para navegadores baseados em firefox.

O suporte não afeta outros navegadores, mantendo as alterações do PR mencionado.

Antes:
![image](https://github.com/user-attachments/assets/24ce8d54-ce6e-4cd5-876b-acc58974c9dd)


Depois:
![image](https://github.com/user-attachments/assets/2d840c4c-e8f4-4486-a306-2c6b7b16b77b)


 (Ignorar o tamanho da barra nos prints, ela aumenta de tamanho quando o mouse passa por cima, quando eu tiro uma screenshot ele para de detectar o mouse e diminui)