### PR TITLE
feat: criando página saúde trans

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -82,9 +82,9 @@ export default function Home() {
             transition={{ duration: 0.5 }}
             className="w-full"
           >
-            <Link href="/sobre" className="block w-full">
+            <Link href="/recursos" className="block w-full">
               <CyberBig
-                text="quem somos"
+                text="recursos"
                 className="text-2xl sm:text-3xl md:text-4xl lg:text-5xl"
               />
             </Link>
@@ -96,9 +96,9 @@ export default function Home() {
             transition={{ duration: 0.6 }}
             className="w-full"
           >
-            <Link href="/recursos" className="block w-full" >
+            <Link href="/blog" className="block w-full" >
               <CyberBig
-                text="recursos"
+                text="blog"
                 className="text-2xl sm:text-3xl md:text-4xl lg:text-5xl"
               />
             </Link>

--- a/src/app/recursos/page.tsx
+++ b/src/app/recursos/page.tsx
@@ -24,10 +24,8 @@ export default function Resources() {
           Recursos
         </CyberContainer>
 
-        <CyberContainer className="font-bold text-accent1 mb-6 text-center">
+        <CyberContainer className="text-accent1 mb-6 text-center">
           Recursos úteis de customização de personagem e informações gerais.
-          <br />
-          Em breve, mais recursos que não sejam sobre hormonios!
           <br />
           <span className="text-accent5">
             Tem algum recurso? Mande pra gente em: cats-trans@riseup.net

--- a/src/app/saude-trans/cartilhas-manuais/page.tsx
+++ b/src/app/saude-trans/cartilhas-manuais/page.tsx
@@ -9,19 +9,26 @@ export default function CartilhasManuais() {
             <CyberContainer className="w-full max-w-4xl border border-accent1 p-1 crt-screen crt-curvature crt-reflection granular-effect">
                 <CyberContainer className="border border-accent1 p-6">
                     <CyberContainer className="text-2xl sm:text-3xl font-bold text-accent1 mb-6 text-center">
-                        Cartilhas e manuais
+                        Cartilhas e Manuais
                     </CyberContainer>
 
                     <CyberContainer className="text-accent1 space-y-6">
                         <section id="cartilha-1">
                             <h2 className="text-xl font-bold text-accent5 mb-4">Cartilha de Retificação de Documentos</h2>
                             <p className="text-accent1 mb-4">
-                                Guia completo sobre como retificar documentos para pessoas trans no Brasil.
+                                Guia completo para retificação do registro civil de pessoas trans.
                             </p>
                             <div className="flex items-center">
                                 <CyberResourceIcon type="link" className="text-accent1 mr-2" />
-                                <a href="https://drive.prefeitura.sp.gov.br/cidade/secretarias/upload/saude/Rede_SAMPA_Trans_16_6_2023.pdf" target="_blank" rel="noopener noreferrer" className="text-accent1 hover:underline">
-                                    Cartilha com o passo-a-passo
+                                <a href="https://drive.google.com/file/d/1W1Bleu0LgUIPlpiLkK4g5SlCg8OBtcEK/view?usp=sharing" target="_blank" rel="noopener noreferrer" className="text-accent1 hover:underline">
+                                    Acessar o guia ANTRA e Casa 1
+                                </a>
+                            </div>
+
+                            <div className="flex items-center">
+                                <CyberResourceIcon type="link" className="text-accent1 mr-2" />
+                                <a href="https://drive.google.com/file/d/1aqPMKN9WQcgqQA1ITORML-_0FCNNIBbH/view?usp=sharing" target="_blank" rel="noopener noreferrer" className="text-accent1 hover:underline">
+                                    Acessar o guia do poupatrans
                                 </a>
                             </div>
                         </section>
@@ -37,7 +44,9 @@ export default function CartilhasManuais() {
                                 <a href="https://diyhrt.wiki/index" target="_blank" rel="noopener noreferrer" className="text-accent1 hover:underline">
                                     https://diyhrt.wiki/index
                                 </a>
-
+                                <span className="text-accent3 text-sm ml-2">
+                                    [em inglês]
+                                </span>
                             </div>
                         </section>
 
@@ -49,8 +58,11 @@ export default function CartilhasManuais() {
                             <div className="flex items-center">
                                 <CyberResourceIcon type="link" className="text-accent1 mr-2" />
                                 <a href="https://drive.google.com/file/d/1mf8n0iVmFJQyfvMFDFtXkfgA5TbOMtV7/view?usp=sharing" target="_blank" rel="noopener noreferrer" className="text-accent1 hover:underline">
-                                    Clique para acessar a zine
+                                    Acessar a zine
                                 </a>
+                                <span className="text-accent3 text-sm ml-2">
+                                    [em inglês]
+                                </span>
                             </div>
                         </section>
 
@@ -59,7 +71,7 @@ export default function CartilhasManuais() {
                             <div className="flex items-center">
                                 <CyberResourceIcon type="link" className="text-accent1 mr-2" />
                                 <a href="https://drive.google.com/file/d/1SGgoHgv3kEENZV4Rv_SVFNyf_FDRgnQI/view?usp=sharing" target="_blank" rel="noopener noreferrer" className="text-accent1 hover:underline">
-                                    Clique para acessar a zine
+                                    Acessar a zine
                                 </a>
                             </div>
                         </section>
@@ -69,8 +81,11 @@ export default function CartilhasManuais() {
                             <div className="flex items-center">
                                 <CyberResourceIcon type="link" className="text-accent1 mr-2" />
                                 <a href="https://drive.google.com/file/d/1orM7Pc8sfVfnyxnsiW7YKoTyViKwMA_a/view?usp=sharing" target="_blank" rel="noopener noreferrer" className="text-accent1 hover:underline">
-                                    Clique para acessar a zine
+                                    Acessar a zine
                                 </a>
+                                <span className="text-accent3 text-sm ml-2">
+                                    [em inglês]
+                                </span>
                             </div>
                         </section>
 
@@ -80,6 +95,19 @@ export default function CartilhasManuais() {
                                 <CyberResourceIcon type="link" className="text-accent1 mr-2" />
                                 <a href="https://transfemscience.org/" target="_blank" rel="noopener noreferrer" className="text-accent1 hover:underline">
                                     https://transfemscience.org/
+                                </a>
+                                <span className="text-accent3 text-sm ml-2">
+                                    [em inglês]
+                                </span>
+                            </div>
+                        </section>
+
+                        <section id="manual-5">
+                            <h2 className="text-xl font-bold text-accent5 mb-4">Guia de Alistamento Militar para Pessoas Trans</h2>
+                            <div className="flex items-center">
+                                <CyberResourceIcon type="link" className="text-accent1 mr-2" />
+                                <a href="https://drive.google.com/file/d/1dqZBqkivbzAibQVSWtzpfPlxL1g_otUL/view?usp=sharing" target="_blank" rel="noopener noreferrer" className="text-accent1 hover:underline">
+                                    Acessar o guia
                                 </a>
                             </div>
                         </section>

--- a/src/app/saude-trans/cartilhas-manuais/page.tsx
+++ b/src/app/saude-trans/cartilhas-manuais/page.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import CyberContainer from "@/components/atoms/CyberContainer";
+import CyberResourceIcon from "@/components/atoms/CyberResourceIcon";
+
+export default function CartilhasManuais() {
+    return (
+        <CyberContainer className="min-h-screen flex flex-col items-center overflow-x-hidden px-4 py-8">
+            <CyberContainer className="w-full max-w-4xl border border-accent1 p-1 crt-screen crt-curvature crt-reflection granular-effect">
+                <CyberContainer className="border border-accent1 p-6">
+                    <CyberContainer className="text-2xl sm:text-3xl font-bold text-accent1 mb-6 text-center">
+                        Cartilhas e manuais
+                    </CyberContainer>
+
+                    <CyberContainer className="text-accent1 space-y-6">
+                        <section id="cartilha-1">
+                            <h2 className="text-xl font-bold text-accent5 mb-4">Cartilha de Retificação de Documentos</h2>
+                            <p className="text-accent1 mb-4">
+                                Guia completo sobre como retificar documentos para pessoas trans no Brasil.
+                            </p>
+                            <div className="flex items-center">
+                                <CyberResourceIcon type="link" className="text-accent1 mr-2" />
+                                <a href="https://drive.prefeitura.sp.gov.br/cidade/secretarias/upload/saude/Rede_SAMPA_Trans_16_6_2023.pdf" target="_blank" rel="noopener noreferrer" className="text-accent1 hover:underline">
+                                    Cartilha com o passo-a-passo
+                                </a>
+                            </div>
+                        </section>
+
+                        <section id="manual-1">
+                            <h2 className="text-xl font-bold text-accent5 mb-4">DIY HRT Directory</h2>
+                            <p className="text-accent1 mb-4">
+                                Informações sobre terapia hormonal DIY (Do It Yourself).
+                            </p>
+                            <div className="flex items-center">
+
+                                <CyberResourceIcon type="link" className="text-accent1 mr-2" />
+                                <a href="https://diyhrt.wiki/index" target="_blank" rel="noopener noreferrer" className="text-accent1 hover:underline">
+                                    https://diyhrt.wiki/index
+                                </a>
+
+                            </div>
+                        </section>
+
+                        <section id="manual-2">
+                            <h2 className="text-xl font-bold text-accent5 mb-4">Guia DIY de Hormonização Transfeminina</h2>
+                            <p className="text-accent1 mb-4 text-accent1">
+                                Guia específico para hormonização transfeminina.
+                            </p>
+                            <div className="flex items-center">
+                                <CyberResourceIcon type="link" className="text-accent1 mr-2" />
+                                <a href="https://drive.google.com/file/d/1mf8n0iVmFJQyfvMFDFtXkfgA5TbOMtV7/view?usp=sharing" target="_blank" rel="noopener noreferrer" className="text-accent1 hover:underline">
+                                    Clique para acessar a zine
+                                </a>
+                            </div>
+                        </section>
+
+                        <section id="manual-3">
+                            <h2 className="text-xl font-bold text-accent5 mb-4">Introdução à Hormonização Transmasculina</h2>
+                            <div className="flex items-center">
+                                <CyberResourceIcon type="link" className="text-accent1 mr-2" />
+                                <a href="https://drive.google.com/file/d/1SGgoHgv3kEENZV4Rv_SVFNyf_FDRgnQI/view?usp=sharing" target="_blank" rel="noopener noreferrer" className="text-accent1 hover:underline">
+                                    Clique para acessar a zine
+                                </a>
+                            </div>
+                        </section>
+
+                        <section id="manual-4">
+                            <h2 className="text-xl font-bold text-accent5 mb-4">Guia DIY de Hormonização Transmasculina</h2>
+                            <div className="flex items-center">
+                                <CyberResourceIcon type="link" className="text-accent1 mr-2" />
+                                <a href="https://drive.google.com/file/d/1orM7Pc8sfVfnyxnsiW7YKoTyViKwMA_a/view?usp=sharing" target="_blank" rel="noopener noreferrer" className="text-accent1 hover:underline">
+                                    Clique para acessar a zine
+                                </a>
+                            </div>
+                        </section>
+
+                        <section id="manual-5">
+                            <h2 className="text-xl font-bold text-accent5 mb-4">Transfeminine Science</h2>
+                            <div className="flex items-center">
+                                <CyberResourceIcon type="link" className="text-accent1 mr-2" />
+                                <a href="https://transfemscience.org/" target="_blank" rel="noopener noreferrer" className="text-accent1 hover:underline">
+                                    https://transfemscience.org/
+                                </a>
+                            </div>
+                        </section>
+                    </CyberContainer>
+                </CyberContainer>
+            </CyberContainer>
+        </CyberContainer>
+    );
+} 

--- a/src/app/saude-trans/casas-acolhimento/page.tsx
+++ b/src/app/saude-trans/casas-acolhimento/page.tsx
@@ -8,7 +8,7 @@ export default function CasasAcolhimento() {
             <CyberContainer className="w-full max-w-4xl border border-accent1 p-1 crt-screen crt-curvature crt-reflection granular-effect">
                 <CyberContainer className="border border-accent1 p-6">
                     <CyberContainer className="text-2xl sm:text-3xl font-bold text-accent1 mb-6 text-center">
-                        Casas de acolhimento
+                        Casas de Acolhimento
                     </CyberContainer>
 
                     <CyberContainer className="text-accent1 space-y-6">
@@ -34,7 +34,7 @@ export default function CasasAcolhimento() {
                             </p>
                             <div className="space-y-2">
                                 <ul className="list-disc list-inside">
-                                    <li>Endereço: Rio de Janeiro - RJ</li>
+                                    <li>Endereço: Rio de Janeiro (não encontramos o endereço exato)</li>
                                     <li>Contato: (21) 96519-2569</li>
                                     <li>Instagram: @casanem_</li>
                                 </ul>
@@ -76,10 +76,24 @@ export default function CasasAcolhimento() {
                             </p>
                             <div className="space-y-2">
                                 <ul className="list-disc list-inside">
-                                    <li>Endereço: Rua Silva Ramos, 839 - Manaus, AM</li>
+                                    <li>Endereço: Rua Silva Ramos, 839 - Praca 14 de Janeiro, Manaus - AM</li>
                                     <li>Contato: contato@casamiga.org</li>
                                     <li>Instagram: @casamigalgbt</li>
                                     <li>Site: <a href="https://linktr.ee/casamigalgbt" target="_blank" rel="noopener noreferrer" className="text-accent1 hover:underline">linktr.ee/casamigalgbt</a></li>
+                                </ul>
+                            </div>
+                        </section>
+
+                        <section id="casa-5">
+                            <h2 className="text-xl font-bold text-accent5 mb-4">Casa Rosa</h2>
+                            <p className="text-accent1 mb-4">
+                                Casa de apoio ao público LGBTQIA+.
+                            </p>
+                            <div className="space-y-2">
+                                <ul className="list-disc list-inside">
+                                    <li>Endereço: Sobradinho - Quadra 17, Nº 45, Brasília - DF</li>
+                                    <li>Contato: fundacaocasarosa@gmail.com | (61) 99220-3745</li>
+                                    <li>Instagram: @casarosadf</li>
                                 </ul>
                             </div>
                         </section>

--- a/src/app/saude-trans/casas-acolhimento/page.tsx
+++ b/src/app/saude-trans/casas-acolhimento/page.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import CyberContainer from "@/components/atoms/CyberContainer";
+
+export default function CasasAcolhimento() {
+    return (
+        <CyberContainer className="min-h-screen flex flex-col items-center overflow-x-hidden px-4 py-8">
+            <CyberContainer className="w-full max-w-4xl border border-accent1 p-1 crt-screen crt-curvature crt-reflection granular-effect">
+                <CyberContainer className="border border-accent1 p-6">
+                    <CyberContainer className="text-2xl sm:text-3xl font-bold text-accent1 mb-6 text-center">
+                        Casas de acolhimento
+                    </CyberContainer>
+
+                    <CyberContainer className="text-accent1 space-y-6">
+                        <section id="casa-1">
+                            <h2 className="text-xl font-bold text-accent5 mb-4">Casa 1</h2>
+                            <p className="text-accent1 mb-4">
+                                Casa de acolhida de jovens LGBT+, centro cultural e clínica de saúde mental gratuita.
+                            </p>
+                            <div className="space-y-2">
+                                <ul className="list-disc list-inside">
+                                    <li>Endereço: Rua Adoniran Barbosa, 151 - Bela Vista, São Paulo - SP</li>
+                                    <li>Contato: contato@casaum.org</li>
+                                    <li>Instagram: @casaum</li>
+                                    <li>Site: <a href="https://www.casaum.org" target="_blank" rel="noopener noreferrer" className="text-accent1 hover:underline">https://www.casaum.org</a></li>
+                                </ul>
+                            </div>
+                        </section>
+
+                        <section id="casa-2">
+                            <h2 className="text-xl font-bold text-accent5 mb-4">Casa Nem</h2>
+                            <p className="text-accent1 mb-4">
+                                Centro de acolhida LGBTQIAPN+ (com atendimento noturno).
+                            </p>
+                            <div className="space-y-2">
+                                <ul className="list-disc list-inside">
+                                    <li>Endereço: Rio de Janeiro - RJ</li>
+                                    <li>Contato: (21) 96519-2569</li>
+                                    <li>Instagram: @casanem_</li>
+                                </ul>
+                            </div>
+                        </section>
+
+                        <section id="casa-3">
+                            <h2 className="text-xl font-bold text-accent5 mb-4">Casa Florescer</h2>
+                            <p className="text-accent1 mb-4">
+                                Centro de acolhida para travestis e mulheres transexuais em situação de vulnerabilidade.
+                            </p>
+                            <div className="space-y-2">
+                                <ul className="list-disc list-inside">
+                                    <li>Endereço: Rua Prates, 1101 - Bom Retiro, São Paulo - SP</li>
+                                    <li>Contato: (11) 3228-0502</li>
+                                    <li>Instagram: @casaflorescer1</li>
+                                </ul>
+                            </div>
+                        </section>
+
+                        <section id="casa-4">
+                            <h2 className="text-xl font-bold text-accent5 mb-4">Casa João Nery</h2>
+                            <p className="text-accent1 mb-4">
+                                Centro de acolhida para homens trans e pessoas transmasculinas em situação de vulnerabilidade.
+                            </p>
+                            <div className="space-y-2">
+                                <ul className="list-disc list-inside">
+                                    <li>Endereço: Rua Carlos Escobar, 86 - Santana, São Paulo - SP</li>
+                                    <li>Contato: caejoaonery@gmail.com</li>
+                                    <li>Instagram: @cajoaonery</li>
+                                </ul>
+                            </div>
+                        </section>
+
+                        <section id="casa-4">
+                            <h2 className="text-xl font-bold text-accent5 mb-4">Casa Miga</h2>
+                            <p className="text-accent1 mb-4">
+                                Centro de referência e casa de acolhimento para pessoas LGBTIA+ do Norte e refugiadas expulsas de casa e/ou em situação de vulnerabilidade social.
+                            </p>
+                            <div className="space-y-2">
+                                <ul className="list-disc list-inside">
+                                    <li>Endereço: Rua Silva Ramos, 839 - Manaus, AM</li>
+                                    <li>Contato: contato@casamiga.org</li>
+                                    <li>Instagram: @casamigalgbt</li>
+                                    <li>Site: <a href="https://linktr.ee/casamigalgbt" target="_blank" rel="noopener noreferrer" className="text-accent1 hover:underline">linktr.ee/casamigalgbt</a></li>
+                                </ul>
+                            </div>
+                        </section>
+                    </CyberContainer>
+                </CyberContainer>
+            </CyberContainer>
+        </CyberContainer>
+    );
+} 

--- a/src/app/saude-trans/page.tsx
+++ b/src/app/saude-trans/page.tsx
@@ -45,7 +45,7 @@ export default function SaudeTrans() {
             <CyberContainer className="w-full max-w-4xl border border-accent1 p-1 crt-screen crt-curvature crt-reflection granular-effect">
                 <CyberContainer className="border border-accent1 p-6">
                     <CyberContainer className="text-2xl sm:text-3xl font-bold text-accent1 mb-6 text-center">
-                        /saude-trans/
+                        Saúde Trans
                     </CyberContainer>
 
                     <CyberContainer className="text-accent1 text-center mb-8">

--- a/src/app/saude-trans/page.tsx
+++ b/src/app/saude-trans/page.tsx
@@ -23,16 +23,16 @@ export default function SaudeTrans() {
             description: "Serviços públicos de saúde com atendimento a pessoas trans"
         },
         {
-            id: "casas-acolhimento", 
+            id: "casas-acolhimento",
             name: "casas-acolhimento",
             path: "/saude-trans/casas-acolhimento",
             description: "Centros de acolhida LGBTQIAPN+"
         },
         {
             id: "cartilhas-manuais",
-            name: "cartilhas-manuais", 
+            name: "cartilhas-manuais",
             path: "/saude-trans/cartilhas-manuais",
-            description: "Guias, cartilhas e manuais sobre saúde, sobrevivência, direitos, etc."
+            description: "Guias, cartilhas e manuais sobre saúde, sobrevivência, direitos, etc"
         }
     ];
 
@@ -60,7 +60,7 @@ export default function SaudeTrans() {
                         <div className="text-accent1 mb-4 font-mono text-sm">
                             <span className="text-accent5">total {directories.length}</span>
                         </div>
-                        
+
                         <div className="space-y-2">
                             {directories.map((dir) => (
                                 <div
@@ -68,9 +68,9 @@ export default function SaudeTrans() {
                                     className="flex items-center p-3 hover:bg-accent1 hover:text-background cursor-pointer border border-transparent hover:border-accent1 transition-all duration-200"
                                     onClick={() => handleDirectoryClick(dir.path)}
                                 >
-                                    <FaFolder 
-                                        size={24} 
-                                        className="text-accent5 mr-4 flex-shrink-0" 
+                                    <FaFolder
+                                        size={24}
+                                        className="text-accent5 mr-4 flex-shrink-0"
                                     />
                                     <div className="flex-1">
                                         <div className="font-mono text-accent5 group-hover:text-background mb-1">
@@ -86,7 +86,7 @@ export default function SaudeTrans() {
                                 </div>
                             ))}
                         </div>
-                        
+
                         <div className="mt-4 pt-4 border-t border-accent1 text-accent3 text-xs font-mono">
                             <span>drwxr-xr-x 3 cats-coletivo-anarquista-trans 4096 {new Date().toLocaleDateString('pt-BR')}.</span>
                         </div>

--- a/src/app/saude-trans/page.tsx
+++ b/src/app/saude-trans/page.tsx
@@ -1,0 +1,90 @@
+// app/saude-trans/page.tsx
+"use client";
+
+import CyberContainer from "@/components/atoms/CyberContainer";
+import CyberDropdown from "@/components/molecules/CyberDropdown";
+import { CyberDropdownItem } from "@/types/dropdown";
+
+export default function SaudeTrans() {
+    const servicosSaudeItems: CyberDropdownItem[] = [
+        {
+            id: "sp-servicos",
+            label: "São Paulo",
+            onClick: () => console.log("São Paulo")
+        },
+        {
+            id: "rj-servicos",
+            label: "Rio de Janeiro",
+            onClick: () => console.log("Rio de Janeiro")
+        }
+    ];
+
+    const casasAcolhimentoItems: CyberDropdownItem[] = [
+        {
+            id: "casa-1",
+            label: "Casa 1",
+            onClick: () => console.log("Casa SP clicked")
+        },
+        {
+            id: "casa-2",
+            label: "Casa Nem",
+            onClick: () => console.log("Casa RJ clicked")
+        }
+    ];
+
+    const cartilhasManuaisItems: CyberDropdownItem[] = [
+        {
+            id: "cartilha-1",
+            label: "Cartilha de Retificação de Documentos",
+            onClick: () => console.log("Cartilha 1 clicked")
+        },
+        {
+            id: "manual-1",
+            label: "Cartilha de DIY Hormonal",
+            onClick: () => console.log("Manual 1 clicked")
+        },
+        {
+            id: "manual-2",
+            label: "Cartilha sobre segurança ",
+            onClick: () => console.log("Manual 2 clicked"),
+            disabled: true
+        }
+    ];
+
+    return (
+        <CyberContainer className="min-h-screen flex flex-col items-center overflow-x-hidden px-4 py-8">
+            <CyberContainer className="w-full max-w-4xl border border-accent1 p-1 crt-screen crt-curvature crt-reflection granular-effect">
+                <CyberContainer className="border border-accent1 p-6">
+                    <CyberContainer className="text-2xl sm:text-3xl font-bold text-accent1 mb-6 text-center">
+                        Saúde Trans
+                    </CyberContainer>
+
+                    <CyberContainer className="text-accent1 text-center mb-6">
+                        Recursos e informações sobre a nossa saúde, incluindo cartilhas, manuais, informações sobre nossos direitos e quais são os serviços públicos de saúde que nos atendem e como acessá-los.
+                        <br />
+                        <span className="text-accent5">
+                            Tem algum recurso? Mande pra gente em: cats-trans@riseup.net
+                        </span>
+                    </CyberContainer>
+
+                    <div className="space-y-4">
+                        <CyberDropdown
+                            title="Serviços de Saúde"
+                            items={servicosSaudeItems}
+                        />
+
+                        <CyberDropdown
+                            title="Casas de Acolhimento"
+                            items={casasAcolhimentoItems}
+                        />
+
+                        <CyberDropdown
+                            title="Cartilhas e Manuais"
+                            items={cartilhasManuaisItems}
+                        />
+                    </div>
+                </CyberContainer>
+            </CyberContainer>
+        </CyberContainer>
+    )
+}

--- a/src/app/saude-trans/page.tsx
+++ b/src/app/saude-trans/page.tsx
@@ -2,87 +2,95 @@
 "use client";
 
 import CyberContainer from "@/components/atoms/CyberContainer";
-import CyberDropdown from "@/components/molecules/CyberDropdown";
-import { CyberDropdownItem } from "@/types/dropdown";
+import { FaFolder } from "react-icons/fa";
+import { useRouter } from "next/navigation";
+
+interface DirectoryItem {
+    id: string;
+    name: string;
+    path: string;
+    description: string;
+}
 
 export default function SaudeTrans() {
-    const servicosSaudeItems: CyberDropdownItem[] = [
+    const router = useRouter();
+
+    const directories: DirectoryItem[] = [
         {
-            id: "sp-servicos",
-            label: "São Paulo",
-            onClick: () => console.log("São Paulo")
+            id: "servicos-publicos",
+            name: "servicos-publicos",
+            path: "/saude-trans/servicos-publicos",
+            description: "Serviços públicos de saúde com atendimento a pessoas trans"
         },
         {
-            id: "rj-servicos",
-            label: "Rio de Janeiro",
-            onClick: () => console.log("Rio de Janeiro")
+            id: "casas-acolhimento", 
+            name: "casas-acolhimento",
+            path: "/saude-trans/casas-acolhimento",
+            description: "Centros de acolhida LGBTQIAPN+"
+        },
+        {
+            id: "cartilhas-manuais",
+            name: "cartilhas-manuais", 
+            path: "/saude-trans/cartilhas-manuais",
+            description: "Guias, cartilhas e manuais sobre saúde, sobrevivência, direitos, etc."
         }
     ];
 
-    const casasAcolhimentoItems: CyberDropdownItem[] = [
-        {
-            id: "casa-1",
-            label: "Casa 1",
-            onClick: () => console.log("Casa SP clicked")
-        },
-        {
-            id: "casa-2",
-            label: "Casa Nem",
-            onClick: () => console.log("Casa RJ clicked")
-        }
-    ];
-
-    const cartilhasManuaisItems: CyberDropdownItem[] = [
-        {
-            id: "cartilha-1",
-            label: "Cartilha de Retificação de Documentos",
-            onClick: () => console.log("Cartilha 1 clicked")
-        },
-        {
-            id: "manual-1",
-            label: "Cartilha de DIY Hormonal",
-            onClick: () => console.log("Manual 1 clicked")
-        },
-        {
-            id: "manual-2",
-            label: "Cartilha sobre segurança ",
-            onClick: () => console.log("Manual 2 clicked"),
-            disabled: true
-        }
-    ];
+    const handleDirectoryClick = (path: string) => {
+        router.push(path);
+    };
 
     return (
         <CyberContainer className="min-h-screen flex flex-col items-center overflow-x-hidden px-4 py-8">
             <CyberContainer className="w-full max-w-4xl border border-accent1 p-1 crt-screen crt-curvature crt-reflection granular-effect">
                 <CyberContainer className="border border-accent1 p-6">
                     <CyberContainer className="text-2xl sm:text-3xl font-bold text-accent1 mb-6 text-center">
-                        Saúde Trans
+                        /saude-trans/
                     </CyberContainer>
 
-                    <CyberContainer className="text-accent1 text-center mb-6">
+                    <CyberContainer className="text-accent1 text-center mb-8">
                         Recursos e informações sobre a nossa saúde, incluindo cartilhas, manuais, informações sobre nossos direitos e quais são os serviços públicos de saúde que nos atendem e como acessá-los.
                         <br />
                         <span className="text-accent5">
-                            Tem algum recurso? Mande pra gente em: cats-trans@riseup.net
+                            Tem algum recurso sobre saúde trans? Mande pra gente em: cats-trans@riseup.net
                         </span>
                     </CyberContainer>
 
-                    <div className="space-y-4">
-                        <CyberDropdown
-                            title="Serviços de Saúde"
-                            items={servicosSaudeItems}
-                        />
-
-                        <CyberDropdown
-                            title="Casas de Acolhimento"
-                            items={casasAcolhimentoItems}
-                        />
-
-                        <CyberDropdown
-                            title="Cartilhas e Manuais"
-                            items={cartilhasManuaisItems}
-                        />
-                    </div>
+                    <CyberContainer className="border border-accent1 p-4 bg-background">
+                        <div className="text-accent1 mb-4 font-mono text-sm">
+                            <span className="text-accent5">total {directories.length}</span>
+                        </div>
+                        
+                        <div className="space-y-2">
+                            {directories.map((dir) => (
+                                <div
+                                    key={dir.id}
+                                    className="flex items-center p-3 hover:bg-accent1 hover:text-background cursor-pointer border border-transparent hover:border-accent1 transition-all duration-200"
+                                    onClick={() => handleDirectoryClick(dir.path)}
+                                >
+                                    <FaFolder 
+                                        size={24} 
+                                        className="text-accent5 mr-4 flex-shrink-0" 
+                                    />
+                                    <div className="flex-1">
+                                        <div className="font-mono text-accent5 group-hover:text-background mb-1">
+                                            {dir.name}/
+                                        </div>
+                                        <div className="text-sm text-accent3 group-hover:text-background">
+                                            {dir.description}
+                                        </div>
+                                    </div>
+                                    <div className="text-accent3 text-sm font-mono ml-4">
+                                        &gt;
+                                    </div>
+                                </div>
+                            ))}
+                        </div>
+                        
+                        <div className="mt-4 pt-4 border-t border-accent1 text-accent3 text-xs font-mono">
+                            <span>drwxr-xr-x 3 cats-coletivo-anarquista-trans 4096 {new Date().toLocaleDateString('pt-BR')}.</span>
+                        </div>
+                    </CyberContainer>
                 </CyberContainer>
             </CyberContainer>
         </CyberContainer>

--- a/src/app/saude-trans/servicos-publicos/page.tsx
+++ b/src/app/saude-trans/servicos-publicos/page.tsx
@@ -5,6 +5,126 @@ import CyberResourceIcon from "@/components/atoms/CyberResourceIcon";
 import CyberDropdown from "@/components/molecules/CyberDropdown";
 
 export default function ServicosPublicos() {
+    // Acre services content
+    const acServicesContent = (
+        <div className="space-y-4">
+            <div className="border border-accent1 p-4">
+                <h3 className="text-lg font-bold text-accent5 mb-3">Centro de Referência LGBT do Acre</h3>
+                <ul className="list-disc list-inside space-y-1">
+                    <li>
+                        Endereço: Rua Francisco Mangabeira, 33 - Bosque, Rio Branco, AC
+                    </li>
+                    <li>
+                        Telefone: (68) 3215-2310
+                    </li>
+                    <li>
+                        E-mail: crsejudh@ac.gov.br
+                    </li>
+                </ul>
+            </div>
+        </div>
+    );
+
+    // Amazonas services content
+    const amServicesContent = (
+        <div className="space-y-4">
+            <div className="border border-accent1 p-4">
+                <h3 className="text-lg font-bold text-accent5 mb-3">Universidade Estadual do Amazonas - Ambulatório de Diversidade Sexual e Gênero</h3>
+                <ul className="list-disc list-inside space-y-1">
+                    <li>
+                        Endereço: Rua Codajás, 26, Cachoeirinha, AM
+                    </li>
+                    <li>
+                        Telefone: (92) 3612-4200 / 4208 / 4217
+                    </li>
+                    <li>
+                        E-mail: dirpam@policodajas.am.gov.br
+                    </li>
+                </ul>
+            </div>
+        </div>
+    );
+
+    // Ceará services content
+    const ceServicesContent = (
+        <div className="space-y-4">
+            <div className="border border-accent1 p-4">
+                <h3 className="text-lg font-bold text-accent5 mb-3">Ambulatório de Saúde Trans do Hospital de Saúde Mental Frota Pinto</h3>
+                <ul className="list-disc list-inside space-y-1">
+                    <li>
+                        Endereço: Rua Vicente Nobre Macêdo, s/n - Messejana, Fortaleza, CE
+                    </li>
+                    <li>
+                        Telefone: (85) 3101-4348
+                    </li>
+                </ul>
+            </div>
+        </div>
+    );
+
+    // Distrito Federal services content
+    const dfServicesContent = (
+        <div className="space-y-4">
+            <div className="border border-accent1 p-4">
+                <h3 className="text-lg font-bold text-accent5 mb-3">Distrito Federal Ambulatório Trans do Hospital Dia</h3>
+                <ul className="list-disc list-inside space-y-1">
+                    <li>
+                        Endereço: Asa Sul EQS 508/509 - Asa Sul, Brasília, DF
+                    </li>
+                    <li>
+                        Telefone: (61) 3445-7529 / 3445-7521
+                    </li>
+                </ul>
+            </div>
+        </div>
+    );
+
+    // Espírito Santo services content
+    const esServicesContent = (
+        <div className="space-y-4">
+            <div className="border border-accent1 p-4">
+                <h3 className="text-lg font-bold text-accent5 mb-3">Hospital Universitário Cassiano Antônio de Moraes</h3>
+                <ul className="list-disc list-inside space-y-1">
+                    <li>
+                        Endereço: Av. Mal. Campos, 1355 - Santos Dumont, Vitória, ES
+                    </li>
+                    <li>
+                        Telefone: (27) 3335-7100
+                    </li>
+                </ul>
+            </div>
+        </div>
+    );
+
+    // Goiás services content
+    const goServicesContent = (
+        <div className="space-y-4">
+            <div className="border border-accent1 p-4">
+                <h3 className="text-lg font-bold text-accent5 mb-3">Univ Fed. de Goiás – Hospital das Clínicas da Universidade Federal de Goiás</h3>
+                <ul className="list-disc list-inside space-y-1">
+                    <li>
+                        Endereço: 1ª Avenida, S/N - Setor Leste Universitário, Goiânia, GO
+                    </li>
+                    <li>
+                        Telefone: (62) 3269-8200
+                    </li>
+                </ul>
+            </div>
+
+            <div className="border border-accent1 p-4">
+                <h3 className="text-lg font-bold text-accent5 mb-3">Ambulatório de Transexualidade do Hospital Geral de Goiânia Alberto Rassi</h3>
+                <ul className="list-disc list-inside space-y-1">
+                    <li>
+                        Endereço: Av. Anhanguera, 6479 - St. Oeste, Goiânia, GO
+                    </li>
+                    <li>
+                        Telefone: (62) 3209-9800
+                    </li>
+                </ul>
+            </div>
+        </div>
+    );
+
     // Rio de Janeiro services content
     const rjServicesContent = (
         <div className="space-y-4">
@@ -12,7 +132,7 @@ export default function ServicosPublicos() {
                 <h3 className="text-lg font-bold text-accent5 mb-3">Amb. de Saúde Int. de Travestis e Transexuais João W. Nery</h3>
                 <ul className="list-disc list-inside space-y-1">
                     <li>Endereço: Av. Ernani do Amaral Peixoto, 169 - Centro, Niterói, RJ</li>
-                    <li>Contato: (21) 2717-8140</li>
+                    <li>Telefone: (21) 2717-8140</li>
                 </ul>
             </div>
         </div>
@@ -41,7 +161,7 @@ export default function ServicosPublicos() {
             <CyberContainer className="w-full max-w-4xl border border-accent1 p-1 crt-screen crt-curvature crt-reflection granular-effect">
                 <CyberContainer className="border border-accent1 p-6">
                     <CyberContainer className="text-2xl sm:text-3xl font-bold text-accent1 mb-6 text-center">
-                        Serviços públicos de saúde
+                        Serviços Públicos de Saúde
                     </CyberContainer>
 
                     <CyberContainer className="text-accent1 mb-6">
@@ -62,6 +182,49 @@ export default function ServicosPublicos() {
                     {/* Services by Region */}
                     <CyberContainer className="space-y-4">
                         <h2 className="text-xl font-bold text-accent5 mb-4">Serviços por região</h2>
+                        <span className="text-accent3 text-sm">Fonte: <a className="text-accent3 hover:underline" href="https://www.saudelgbtqia.com/assistenciaestadual" target="_blank" rel="noopener noreferrer">ambulatórios estaduais de saúde trans e centros de acolhimento LGBTQIA+</a></span>
+
+                        {/* Acre */}
+                        <CyberDropdown
+                            title="Acre"
+                            content={acServicesContent}
+                            className="w-full max-w-4xl"
+                        />
+
+                        {/* Amazonas */}
+                        <CyberDropdown
+                            title="Amazonas"
+                            content={amServicesContent}
+                            className="w-full max-w-4xl"
+                        />
+
+                        {/* Ceará */}
+                        <CyberDropdown
+                            title="Ceará"
+                            content={ceServicesContent}
+                            className="w-full max-w-4xl"
+                        />
+
+                        {/* Distrito Federal */}
+                        <CyberDropdown
+                            title="Distrito Federal"
+                            content={dfServicesContent}
+                            className="w-full max-w-4xl"
+                        />
+
+                        {/* Espírito Santo */}
+                        <CyberDropdown
+                            title="Espírito Santo"
+                            content={esServicesContent}
+                            className="w-full max-w-4xl"
+                        />
+
+                        {/* Goiás */}
+                        <CyberDropdown
+                            title="Goiás"
+                            content={goServicesContent}
+                            className="w-full max-w-4xl"
+                        />
 
                         {/* Rio de Janeiro */}
                         <CyberDropdown

--- a/src/app/saude-trans/servicos-publicos/page.tsx
+++ b/src/app/saude-trans/servicos-publicos/page.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import CyberContainer from "@/components/atoms/CyberContainer";
+import CyberResourceIcon from "@/components/atoms/CyberResourceIcon";
+import CyberDropdown from "@/components/molecules/CyberDropdown";
+
+export default function ServicosPublicos() {
+    // Rio de Janeiro services content
+    const rjServicesContent = (
+        <div className="space-y-4">
+            <div className="border border-accent1 p-4">
+                <h3 className="text-lg font-bold text-accent5 mb-3">Amb. de Saúde Int. de Travestis e Transexuais João W. Nery</h3>
+                <ul className="list-disc list-inside space-y-1">
+                    <li>Endereço: Av. Ernani do Amaral Peixoto, 169 - Centro, Niterói, RJ</li>
+                    <li>Contato: (21) 2717-8140</li>
+                </ul>
+            </div>
+        </div>
+    );
+
+    // São Paulo services content
+    const spServicesContent = (
+        <div className="space-y-4">
+            <div className="border border-accent1 p-4">
+                <h3 className="text-lg font-bold text-accent5 mb-3">Rede Sampa Trans</h3>
+                <div className="space-y-2">
+                    <p className="text-accent3 text-sm">Centros de atendimento disponíveis por região:</p>
+                    <div className="flex items-center">
+                        <CyberResourceIcon type="link" className="text-accent1 mr-2" />
+                        <a href="https://drive.prefeitura.sp.gov.br/cidade/secretarias/upload/saude/Rede_SAMPA_Trans_16_6_2023.pdf" target="_blank" rel="noopener noreferrer" className="text-accent1 hover:underline">
+                            Documento oficial com lista de centros
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+
+    return (
+        <CyberContainer className="min-h-screen flex flex-col items-center overflow-x-hidden px-4 py-8">
+            <CyberContainer className="w-full max-w-4xl border border-accent1 p-1 crt-screen crt-curvature crt-reflection granular-effect">
+                <CyberContainer className="border border-accent1 p-6">
+                    <CyberContainer className="text-2xl sm:text-3xl font-bold text-accent1 mb-6 text-center">
+                        Serviços públicos de saúde
+                    </CyberContainer>
+
+                    <CyberContainer className="text-accent1 mb-6">
+                        <p className="font-bold mb-4">
+                            Dispositivos legais para a população trans no Brasil
+                        </p>
+                        <ul className="list-disc list-inside space-y-2 text-sm">
+                            <li>Portaria n. 457, de 21 de agosto de 2008 - Define as diretrizes nacionais para o processo transexalizador no Sistema Único de Saúde (SUS), a serem implantadas em todos os estados e na unidade federal.</li>
+                            <li>Portaria n. 2803, de 19 de novembro de 2013 - Redefine e amplia o processo transexualizador no Sistema Único de Saúde (SUS).</li>
+                            <li>Resolução nº 11, de 18 de dezembro de 2014 - Estabelece os parâmetros para a inclusão dos itens "orientação sexual", "identidade de gênero" e "nome social" nos boletins de ocorrência emitidos pelas autoridades policiais no Brasil.</li>
+                            <li>Decreto nº 8.727, de 28 de abril de 2016 - Dispõe sobre o uso do nome social e o reconhecimento da identidade de gênero de pessoas travestis e transexuais no âmbito da administração pública federal direta, autárquica e fundacional.</li>
+                            <li>Provimento nº 73/28 de junho de 2018 - Regulamentou a retificação do registro civil e todos os cartórios de registro de pessoas do Brasil ficaram obrigados a realizar a alteração de nome e marcador de gênero nas certidões de nascimento.</li>
+                            <li>Portaria nº 1.370, de 21 de junho de 2019 - Inclui oficialmente na tabela de procedimentos, medicamentos, óteses, próteses e materiais especiais do SUS um novo procedimento relacionado à redesignação sexual de pessoas transmasculinas.</li>
+                            <li>Portaria nº 1.693, de 10 de maio de 2024 - Garante que procedimentos de ginecologia, obstetrícia, urologia e proctologia no SUS estejam acessíveis a todas as pessoas, independentemente do sexo registrado, com base na identidade de gênero autodeterminada.</li>
+                        </ul>
+                    </CyberContainer>
+
+                    {/* Services by Region */}
+                    <CyberContainer className="space-y-4">
+                        <h2 className="text-xl font-bold text-accent5 mb-4">Serviços por região</h2>
+
+                        {/* Rio de Janeiro */}
+                        <CyberDropdown
+                            title="Rio de Janeiro"
+                            content={rjServicesContent}
+                            className="w-full max-w-4xl"
+                        />
+
+                        {/* São Paulo */}
+                        <CyberDropdown
+                            title="São Paulo"
+                            content={spServicesContent}
+                            className="w-full max-w-4xl"
+                        />
+                    </CyberContainer>
+                </CyberContainer>
+            </CyberContainer>
+        </CyberContainer>
+    );
+} 

--- a/src/components/molecules/CyberDropdown/index.tsx
+++ b/src/components/molecules/CyberDropdown/index.tsx
@@ -1,17 +1,23 @@
 "use client";
 
-import { useState } from "react";
+import { useState, ReactNode } from "react";
 import CyberContainer from "@/components/atoms/CyberContainer";
 import { CyberDropdownProps } from "@/types/dropdown";
+
+interface EnhancedCyberDropdownProps extends Omit<CyberDropdownProps, 'items'> {
+    items?: CyberDropdownProps['items'];
+    content?: ReactNode;
+}
 
 export default function CyberDropdown({
     title,
     items,
+    content,
     className = "",
     defaultOpen = false,
     maxHeight = "max-h-96",
     onToggle
-}: CyberDropdownProps) {
+}: EnhancedCyberDropdownProps) {
     const [isOpen, setIsOpen] = useState(defaultOpen);
 
     const toggleDropdown = () => {
@@ -45,7 +51,13 @@ export default function CyberDropdown({
                 {isOpen && (
                     <div className="border-t border-accent1 bg-background">
                         <div className={`p-4 space-y-3 overflow-y-auto ${maxHeight}`}>
-                            {items.map((item) => (
+                            {content && (
+                                <div className="text-accent1">
+                                    {content}
+                                </div>
+                            )}
+                            
+                            {items && items.map((item) => (
                                 <div
                                     key={item.id}
                                     className={`p-2 border-l-2 border-transparent transition-all duration-200 flex items-center gap-2 ${item.disabled

--- a/src/components/molecules/CyberDropdown/index.tsx
+++ b/src/components/molecules/CyberDropdown/index.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useState } from "react";
+import CyberContainer from "@/components/atoms/CyberContainer";
+import { CyberDropdownProps } from "@/types/dropdown";
+
+export default function CyberDropdown({
+    title,
+    items,
+    className = "",
+    defaultOpen = false,
+    maxHeight = "max-h-96",
+    onToggle
+}: CyberDropdownProps) {
+    const [isOpen, setIsOpen] = useState(defaultOpen);
+
+    const toggleDropdown = () => {
+        const newIsOpen = !isOpen;
+        setIsOpen(newIsOpen);
+        onToggle?.(newIsOpen);
+    };
+
+    return (
+        <CyberContainer className={`w-full max-w-2xl mx-auto ${className}`}>
+            <div className="border border-accent1 rounded-none">
+                <button
+                    onClick={toggleDropdown}
+                    className="w-full p-4 bg-transparent border-none text-left flex items-center justify-between text-accent1 hover:text-accent5 transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-accent1"
+                >
+                    <span className="text-lg font-semibold">{title}</span>
+                    <svg
+                        className={`w-5 h-5 transition-transform duration-200 ${isOpen ? 'rotate-180' : 'rotate-0'
+                            }`}
+                        viewBox="0 0 20 20"
+                        fill="currentColor"
+                    >
+                        <path
+                            fillRule="evenodd"
+                            d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
+                            clipRule="evenodd"
+                        />
+                    </svg>
+                </button>
+
+                {isOpen && (
+                    <div className="border-t border-accent1 bg-background">
+                        <div className={`p-4 space-y-3 overflow-y-auto ${maxHeight}`}>
+                            {items.map((item) => (
+                                <div
+                                    key={item.id}
+                                    className={`p-2 border-l-2 border-transparent transition-all duration-200 flex items-center gap-2 ${item.disabled
+                                            ? 'text-accent3 cursor-not-allowed opacity-50'
+                                            : 'text-accent1 hover:text-accent5 cursor-pointer hover:border-accent5'
+                                        }`}
+                                    onClick={item.disabled ? undefined : item.onClick}
+                                >
+                                    {item.icon && <span className="flex-shrink-0">{item.icon}</span>}
+                                    <span>{item.label}</span>
+                                </div>
+                            ))}
+                        </div>
+                    </div>
+                )}
+            </div>
+        </CyberContainer>
+    );
+} 

--- a/src/components/organism/CyberSidebar/CyberSidebarIcons.tsx
+++ b/src/components/organism/CyberSidebar/CyberSidebarIcons.tsx
@@ -56,7 +56,7 @@ export const BlogIcon = ({ className = "" }: { className?: string }) => (
   </svg>
 );
 
-export const ArchiveIcon = ({ className = "" }: { className?: string }) => (
+export const ResourcesIcon = ({ className = "" }: { className?: string }) => (
   <svg
     width="16"
     height="16"
@@ -348,6 +348,31 @@ export const CustomizationIcon = ({
   >
     <path
       d="M8 2L10 6L14 7L11 10L11 14L8 12L5 14L5 10L2 7L6 6L8 2Z"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+export const ArchiveIcon = ({ className = "" }: { className?: string }) => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 16 16"
+    fill="none"
+    className={`mr-1 ${className}`}
+  >
+
+    <path
+      d="M3 2V14H13V5L10 2H3Z"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinejoin="round"
+    />
+
+    <path
+      d="M10 2V5H13"
       stroke="currentColor"
       strokeWidth="1.5"
       strokeLinejoin="round"

--- a/src/components/organism/CyberSidebar/index.tsx
+++ b/src/components/organism/CyberSidebar/index.tsx
@@ -12,6 +12,7 @@ import {
   HomeIcon,
   BlogIcon,
   HealthIcon,
+  ResourcesIcon,
   ArchiveIcon,
   AboutIcon,
   HamburgerIcon,
@@ -236,7 +237,7 @@ export default function CyberSidebar() {
       <motion.div variants={itemVariants}>
         <Link href="/recursos" passHref >
           <CyberMiniButton className="flex items-center w-full hover:bg-accent1 hover:text-background">
-            <ArchiveIcon />
+            <ResourcesIcon />
             <span>recursos</span>
           </CyberMiniButton>
         </Link>

--- a/src/components/organism/CyberSidebar/index.tsx
+++ b/src/components/organism/CyberSidebar/index.tsx
@@ -11,7 +11,6 @@ import {
   FolderIcon,
   HomeIcon,
   BlogIcon,
-  HealthIcon,
   ResourcesIcon,
   ArchiveIcon,
   AboutIcon,
@@ -81,6 +80,7 @@ interface CyberSection {
 
 type ExpandedNodes = {
   "manifesto-root": boolean;
+  "saude-trans-root": boolean;
 };
 
 const HARDCODED_SECTIONS = {
@@ -145,6 +145,11 @@ const HARDCODED_SECTIONS = {
       label: "3.7 - Pelo direito à reprodução queer",
     },
   ],
+  saudeTrans: [
+    { id: "servicos-publicos", parent: "saude-trans", label: "serviços públicos" },
+    { id: "casas-acolhimento", parent: "saude-trans", label: "casas de acolhimento" },
+    { id: "cartilhas-manuais", parent: "saude-trans", label: "cartilhas e manuais" },
+  ],
 };
 
 export default function CyberSidebar() {
@@ -156,23 +161,35 @@ export default function CyberSidebar() {
   const [open, setOpen] = useState(false);
   const [expandedNodes, setExpandedNodes] = useState<ExpandedNodes>({
     "manifesto-root": false,
+    "saude-trans-root": false,
   });
   const [manifestoSections, setManifestoSections] = useState<CyberSection[]>(
+    []
+  );
+  const [saudeTransSections, setSaudeTransSections] = useState<CyberSection[]>(
     []
   );
 
   useEffect(() => {
     if (cyberSections.length === 0) {
-      loadSections(HARDCODED_SECTIONS.manifesto);
+      loadSections([...HARDCODED_SECTIONS.manifesto, ...HARDCODED_SECTIONS.saudeTrans]);
       setManifestoSections(HARDCODED_SECTIONS.manifesto);
+      setSaudeTransSections(HARDCODED_SECTIONS.saudeTrans);
     } else {
       const manifestos = cyberSections.filter((s) => s.parent === "manifesto");
+      const saudeTranss = cyberSections.filter((s) => s.parent === "saude-trans");
       setManifestoSections(manifestos);
+      setSaudeTransSections(saudeTranss);
     }
   }, [cyberSections, loadSections]);
 
   const handleSectionClick = (id: string) => {
     router.push(`/manifesto#${id}`);
+    setOpen(false);
+  };
+
+  const handleSaudeTransSectionClick = (id: string) => {
+    router.push(`/saude-trans/${id}`);
     setOpen(false);
   };
 
@@ -252,13 +269,54 @@ export default function CyberSidebar() {
         </Link>
       </motion.div>
 
-      <motion.div variants={itemVariants}>
-        <Link href="/saude-trans" passHref >
-          <CyberMiniButton className="flex items-center w-full hover:bg-accent1 hover:text-background">
-            <HealthIcon />
-            <span>saúde trans</span>
-          </CyberMiniButton>
-        </Link>
+      <motion.div variants={itemVariants} className="mb-1">
+        <div
+          className="flex items-center px-2 py-1 cursor-pointer hover:bg-accent1 hover:text-background"
+          onClick={() => toggleNode("saude-trans-root")}
+        >
+          <FolderIcon isOpen={expandedNodes["saude-trans-root"]} />
+          <span>saúde trans</span>
+        </div>
+
+        <AnimatePresence>
+          {expandedNodes["saude-trans-root"] && (
+            <motion.div
+              className="ml-6 pl-2 border-l border-accent1 overflow-hidden"
+              variants={subContainerVariants}
+              initial="hidden"
+              animate="visible"
+              exit="exit"
+            >
+              <motion.div
+                className="hover:bg-accent1 hover:text-background cursor-pointer px-2 py-1"
+                onClick={() => router.push("/saude-trans")}
+                variants={subItemVariants}
+              >
+                <div className="flex items-center">
+                  <span className="mr-1">---</span>
+                  <span className="ml-2 whitespace-nowrap overflow-hidden text-ellipsis max-w-[180px]">
+                    geral
+                  </span>
+                </div>
+              </motion.div>
+              {saudeTransSections.map((section) => (
+                <motion.div
+                  key={section.id}
+                  className="hover:bg-accent1 hover:text-background cursor-pointer px-2 py-1"
+                  onClick={() => handleSaudeTransSectionClick(section.id)}
+                  variants={subItemVariants}
+                >
+                  <div className="flex items-center">
+                    <span className="mr-1">---</span>
+                    <span className="ml-2 whitespace-nowrap overflow-hidden text-ellipsis max-w-[180px]">
+                      {section.label}
+                    </span>
+                  </div>
+                </motion.div>
+              ))}
+            </motion.div>
+          )}
+        </AnimatePresence>
       </motion.div>
 
       <motion.div variants={itemVariants}>

--- a/src/components/organism/CyberSidebar/index.tsx
+++ b/src/components/organism/CyberSidebar/index.tsx
@@ -11,6 +11,7 @@ import {
   FolderIcon,
   HomeIcon,
   BlogIcon,
+  HealthIcon,
   ArchiveIcon,
   AboutIcon,
   HamburgerIcon,
@@ -242,19 +243,28 @@ export default function CyberSidebar() {
       </motion.div>
 
       <motion.div variants={itemVariants}>
-        <Link href="/blog" passHref >
+        <Link href="/arquivos" passHref >
           <CyberMiniButton className="flex items-center w-full hover:bg-accent1 hover:text-background">
-            <BlogIcon />
-            <span>blog</span>
+            <ArchiveIcon />
+            <span>arquivos</span>
           </CyberMiniButton>
         </Link>
       </motion.div>
 
       <motion.div variants={itemVariants}>
-        <Link href="/arquivos" passHref >
+        <Link href="/saude-trans" passHref >
           <CyberMiniButton className="flex items-center w-full hover:bg-accent1 hover:text-background">
-            <ArchiveIcon />
-            <span>arquivos</span>
+            <HealthIcon />
+            <span>saúde trans</span>
+          </CyberMiniButton>
+        </Link>
+      </motion.div>
+
+      <motion.div variants={itemVariants}>
+        <Link href="/blog" passHref >
+          <CyberMiniButton className="flex items-center w-full hover:bg-accent1 hover:text-background">
+            <BlogIcon />
+            <span>blog</span>
           </CyberMiniButton>
         </Link>
       </motion.div>

--- a/src/data/resources.ts
+++ b/src/data/resources.ts
@@ -2,58 +2,7 @@
 import {CyberResource} from "@/components/molecules/CyberResourceCard";
 
 export const resourcesByCategory: Record<string, CyberResource[]> = {
-  Hormonização: [
-    {
-      id: '1',
-      title: 'DIY HRT Directory',
-      type: 'link',
-      url: 'https://diyhrt.wiki/index',
-      description: 'Como realizar auto-hormonização (DIY) de forma segura',
-      category: 'Hormonização',
-      dateAdded: '2025-03-28',
-    },
-  ],
-  Transmasc: [
-    {
-      id: '2',
-      title: 'Introdução a hormonização transmasculina',
-      type: 'file',
-      url: "https://drive.google.com/file/d/1SGgoHgv3kEENZV4Rv_SVFNyf_FDRgnQI/view?usp=sharing",
-      description: 'Guia introdutório a hormonização para transmasculines',
-      category: 'Transmasc',
-      dateAdded: '2025-03-28',
-    },
-    {
-      id: '3',
-      title: 'Guia DIY de hormonização transmasculina',
-      type: 'file',
-      url: "https://drive.google.com/file/d/1orM7Pc8sfVfnyxnsiW7YKoTyViKwMA_a/view?usp=sharing",
-      description: 'Guia de hormonização DIY para transmasculines',
-      category: 'Transmasc',
-      dateAdded: '2025-03-28',
-    },
-  ],
-  Transfem: [
-    {
-      id: '4',
-      title: 'Guia DIY de hormonização transfeminina',
-      type: 'file',
-      url: "https://drive.google.com/file/d/1mf8n0iVmFJQyfvMFDFtXkfgA5TbOMtV7/view?usp=sharing",
-      description: 'Guia de hormonização DIY para transfeminines',
-      category: 'Transfem',
-      dateAdded: '2025-03-28',
-    },
-    {
-      id: '5',
-      title: 'Transfeminine Science',
-      type: 'link',
-      url: 'https://transfemscience.org/',
-      description: 'Recursos científicos para pessoas transfeminines',
-      category: 'Transfem',
-      dateAdded: '2025-03-28',
-    },
-  ],
-   ColetividadeTrans: [
+   ColetivosTrans: [
     {
      id: '6',
      title: 'Acervo trans-anarquista',
@@ -81,10 +30,19 @@ export const resourcesByCategory: Record<string, CyberResource[]> = {
       category: 'Coletivos',
       dateAdded: '2025-06-03',
     },
+    {
+      id: '9',
+      title: 'revolta anarkokuir',
+      type: 'link',
+      url: 'https://anarkokuir.hotglue.me/',
+      description: 'Coletivo anarquista queer.',
+      category: 'Coletivos',
+      dateAdded: '2025-06-21',
+    }
   ],
    Cyberhormônios: [
     {
-      id: '9',
+      id: '10',
       title: 'Piccrew - Criador de corpos-virtuais',
       type: 'link',
       url: 'https://picrew.me/en/search',

--- a/src/types/dropdown.ts
+++ b/src/types/dropdown.ts
@@ -1,0 +1,16 @@
+export interface CyberDropdownItem {
+  id: string;
+  label: string;
+  onClick?: () => void;
+  disabled?: boolean;
+  icon?: React.ReactNode;
+}
+
+export interface CyberDropdownProps {
+  title: string;
+  items: CyberDropdownItem[];
+  className?: string;
+  defaultOpen?: boolean;
+  maxHeight?: string;
+  onToggle?: (isOpen: boolean) => void;
+} 


### PR DESCRIPTION
> criando página 'saúde trans' no site

foi criada uma nova rota: `/saude-trans`, com três sub-rotas: `/servicos-publicos`, `/casas-acolhimento` e `/cartilhas-manuais`.
são páginas criadas com o intuito de fazer com que as pessoas possam acessar informações sobre saúde de maneira mais fácil, com informações de direitos que temos através do SUS, alguns dos serviços disponíveis em cada estado e endereço e contato, assim como as casas de acolhimento que podem auxiliar e abrigar pessoas trans em situação de vulnerabilidade. a página de cartilhas e manuais contém guias para retificação de nome, alistamento militar para pessoas trans e os arquivos de hormonização DIY que antes estavam na página de recursos.

💯 
